### PR TITLE
Proper order of past jobs

### DIFF
--- a/operator_service/data_store.py
+++ b/operator_service/data_store.py
@@ -138,7 +138,7 @@ def get_sql_past_jobs(from_timestamp, limit):
     select_query = '''
     SELECT agreementId, workflowId, owner, status, statusText, 
         extract(epoch from dateCreated) as dateCreated, 
-        namespace,workflow FROM jobs WHERE dateFinished IS NOT NULL AND dateFinished>=%(dateFinished)s ORDER by dateFinished DESC LIMIT %(limit)s
+        namespace,workflow FROM jobs WHERE dateFinished IS NOT NULL AND dateFinished < %(dateFinished)s ORDER by dateFinished DESC LIMIT %(limit)s
     '''
     params['dateFinished'] = from_timestamp
     params['limit'] = limit


### PR DESCRIPTION
Since the feature is indented for pagination, the flow should be:
 - get 10 jobs, with timestamp lower then current timestamp
 - next page, get 10 jobs with timestamp lower then last result of previous page
etc